### PR TITLE
Fix name and add link for CDK

### DIFF
--- a/Lesson-03/README.md
+++ b/Lesson-03/README.md
@@ -2,7 +2,7 @@
 
 ## Readings
 
-- AWS CloudDeveloper Kit
+- [AWS Cloud Development Kit](https://aws.amazon.com/cdk/)
 
 ## Homework
 


### PR DESCRIPTION
*Description of changes:*

Googling for "CloudDeveloper Kit" was not as good as "Cloud Development Kit". But no googling at all is best.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
